### PR TITLE
New "cbInfoPar" function

### DIFF
--- a/pkg/R/infoPar.r
+++ b/pkg/R/infoPar.r
@@ -1,0 +1,18 @@
+
+cbInfoPar <- function(tag) {
+    p <- cbPar("infopar")
+    
+    # return all valid parameters
+    if(missing(tag)) {  
+        p <- p[p$is.final == TRUE, c("tag","par")]
+        row.names(p) <- NULL
+    }
+    
+    # return valid parameters for "tag"
+    else {
+        p <- p[p$tag == tag & p$is.final == TRUE, c("tag","par")]
+        row.names(p) <- NULL
+    }
+    
+    return(p)
+}


### PR DESCRIPTION
Implemented "cbInfoPar" function that returns:
- all valid parameters (final nodes) 
  or
- final nodes for specific tag
